### PR TITLE
Update regex to support branches with `/`

### DIFF
--- a/gitprompt
+++ b/gitprompt
@@ -22,7 +22,7 @@ function parse_git_branch {
   git rev-parse --git-dir &> /dev/null
 
   git_status="$(git status 2> /dev/null)"
-  branch_pattern="^On branch ([-_A-Za-z0-9]*)[^A-Za-z0-9]"
+  branch_pattern="^On branch ([-_A-Za-z0-9\/]*)[^A-Za-z0-9]"
   remote_pattern="Your branch is (.*) of"
   diverge_pattern="Your branch and (.*) have diverged"
 


### PR DESCRIPTION
So, I just noticed this. It could probably be improved, but worksforme 